### PR TITLE
Refactor Compose structure

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/github/arashiyama11/dncl_ide/ui/app/App.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/arashiyama11/dncl_ide/ui/app/App.kt
@@ -1,4 +1,4 @@
-package io.github.arashiyama11.dncl_ide.ui
+package io.github.arashiyama11.dncl_ide.ui.app
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
@@ -73,6 +73,13 @@ import io.github.arashiyama11.dncl_ide.adapter.SelectNotebookScreenViewModel
 import io.github.arashiyama11.dncl_ide.domain.notebook.CellType
 import io.github.arashiyama11.dncl_ide.ui.components.isImeVisible
 import io.github.arashiyama11.dncl_ide.ui.components.rememberDarkThemeStateFlow
+import io.github.arashiyama11.dncl_ide.ui.screen.CodingScreen
+import io.github.arashiyama11.dncl_ide.ui.screen.SelectFileScreen
+import io.github.arashiyama11.dncl_ide.ui.screen.SelectNotebookScreen
+import io.github.arashiyama11.dncl_ide.ui.screen.SettingsScreen
+import io.github.arashiyama11.dncl_ide.ui.screen.LicencesScreen
+import io.github.arashiyama11.dncl_ide.ui.screen.SingleLicenseScreen
+import io.github.arashiyama11.dncl_ide.ui.DnclIdeTheme
 import kotlinx.serialization.Serializable
 import org.koin.compose.viewmodel.koinViewModel
 

--- a/composeApp/src/commonMain/kotlin/io/github/arashiyama11/dncl_ide/ui/components/CodeEditor.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/arashiyama11/dncl_ide/ui/components/CodeEditor.kt
@@ -1,4 +1,4 @@
-package io.github.arashiyama11.dncl_ide.ui
+package io.github.arashiyama11.dncl_ide.ui.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -45,6 +45,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import io.github.arashiyama11.dncl_ide.ui.LocalCodeTypography
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 

--- a/composeApp/src/commonMain/kotlin/io/github/arashiyama11/dncl_ide/ui/components/IdeSideButtons.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/arashiyama11/dncl_ide/ui/components/IdeSideButtons.kt
@@ -1,4 +1,4 @@
-package io.github.arashiyama11.dncl_ide.ui
+package io.github.arashiyama11.dncl_ide.ui.components
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.BorderStroke

--- a/composeApp/src/commonMain/kotlin/io/github/arashiyama11/dncl_ide/ui/layout/DnclIDEVertical.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/arashiyama11/dncl_ide/ui/layout/DnclIDEVertical.kt
@@ -1,4 +1,4 @@
-package io.github.arashiyama11.dncl_ide.ui
+package io.github.arashiyama11.dncl_ide.ui.layout
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Arrangement
@@ -33,12 +33,15 @@ import io.github.arashiyama11.dncl_ide.adapter.IdeViewModel
 import io.github.arashiyama11.dncl_ide.adapter.TextFieldType
 import io.github.arashiyama11.dncl_ide.ui.components.EnvironmentDebugView
 import io.github.arashiyama11.dncl_ide.ui.components.SuggestionListView
+import io.github.arashiyama11.dncl_ide.ui.components.CodeEditor
+import io.github.arashiyama11.dncl_ide.ui.components.IdeSideButtons
+import io.github.arashiyama11.dncl_ide.ui.LocalCodeTypography
 import org.koin.compose.viewmodel.koinViewModel
 
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun DnclIDE(modifier: Modifier = Modifier, viewModel: IdeViewModel = koinViewModel()) {
+fun DnclIDEVertical(modifier: Modifier = Modifier, viewModel: IdeViewModel = koinViewModel()) {
     val uiState by viewModel.uiState.collectAsState()
 
 

--- a/composeApp/src/commonMain/kotlin/io/github/arashiyama11/dncl_ide/ui/screen/CodingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/arashiyama11/dncl_ide/ui/screen/CodingScreen.kt
@@ -1,4 +1,4 @@
-package io.github.arashiyama11.dncl_ide.ui
+package io.github.arashiyama11.dncl_ide.ui.screen
 
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -12,6 +12,7 @@ import io.github.arashiyama11.dncl_ide.domain.model.Entry
 import io.github.arashiyama11.dncl_ide.domain.model.NotebookFile
 import io.github.arashiyama11.dncl_ide.domain.model.ProgramFile
 import io.github.arashiyama11.dncl_ide.domain.repository.FileRepository
+import io.github.arashiyama11.dncl_ide.ui.layout.DnclIDEVertical
 import org.koin.compose.koinInject
 
 @Composable
@@ -27,7 +28,7 @@ fun CodingScreen(fileRepository: FileRepository = koinInject()) {
     }
     when (entry) {
         is NotebookFile -> NotebookScreen()
-        is ProgramFile -> DnclIDE()
+        is ProgramFile -> DnclIDEVertical()
         else -> {
             Text("No file selected or unsupported file type")
         }

--- a/composeApp/src/commonMain/kotlin/io/github/arashiyama11/dncl_ide/ui/screen/LicensesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/arashiyama11/dncl_ide/ui/screen/LicensesScreen.kt
@@ -1,4 +1,4 @@
-package io.github.arashiyama11.dncl_ide.ui
+package io.github.arashiyama11.dncl_ide.ui.screen
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement

--- a/composeApp/src/commonMain/kotlin/io/github/arashiyama11/dncl_ide/ui/screen/NotebookScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/arashiyama11/dncl_ide/ui/screen/NotebookScreen.kt
@@ -1,4 +1,4 @@
-package io.github.arashiyama11.dncl_ide.ui
+package io.github.arashiyama11.dncl_ide.ui.screen
 
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -63,6 +63,8 @@ import com.mikepenz.markdown.compose.Markdown
 import com.mikepenz.markdown.model.MarkdownColors
 import com.mikepenz.markdown.model.MarkdownTypography
 import io.github.arashiyama11.dncl_ide.ui.components.SuggestionListView
+import io.github.arashiyama11.dncl_ide.ui.components.CodeEditor
+import io.github.arashiyama11.dncl_ide.ui.LocalCodeTypography
 import org.koin.compose.viewmodel.koinViewModel
 
 

--- a/composeApp/src/commonMain/kotlin/io/github/arashiyama11/dncl_ide/ui/screen/SelectFileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/arashiyama11/dncl_ide/ui/screen/SelectFileScreen.kt
@@ -1,4 +1,4 @@
-package io.github.arashiyama11.dncl_ide.ui
+package io.github.arashiyama11.dncl_ide.ui.screen
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable

--- a/composeApp/src/commonMain/kotlin/io/github/arashiyama11/dncl_ide/ui/screen/SelectNotebookScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/arashiyama11/dncl_ide/ui/screen/SelectNotebookScreen.kt
@@ -1,4 +1,4 @@
-package io.github.arashiyama11.dncl_ide.ui
+package io.github.arashiyama11.dncl_ide.ui.screen
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row

--- a/composeApp/src/commonMain/kotlin/io/github/arashiyama11/dncl_ide/ui/screen/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/arashiyama11/dncl_ide/ui/screen/SettingsScreen.kt
@@ -1,4 +1,4 @@
-package io.github.arashiyama11.dncl_ide.ui
+package io.github.arashiyama11.dncl_ide.ui.screen
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Arrangement

--- a/composeApp/src/desktopMain/kotlin/io/github/arashiyama11/dncl_ide/main.kt
+++ b/composeApp/src/desktopMain/kotlin/io/github/arashiyama11/dncl_ide/main.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.window.application
 import androidx.compose.ui.window.rememberWindowState
 import io.github.arashiyama11.dncl_ide.domain.domainModule
 import io.github.arashiyama11.dncl_ide.domain.model.EntryPath
-import io.github.arashiyama11.dncl_ide.ui.App
+import io.github.arashiyama11.dncl_ide.ui.app.App
 import io.github.arashiyama11.dncl_ide.util.RootPathProvider
 import org.koin.core.context.startKoin
 import org.koin.dsl.bind


### PR DESCRIPTION
## Summary
- move `App` and navigation into `ui.app` package
- split out screens to `ui.screen`
- introduce `ui.layout` with `DnclIDEVertical` layout
- move `CodeEditor` and `IdeSideButtons` to components
- update entry point import

## Testing
- `./gradlew :composeApp:compileKotlinDesktop --no-daemon --console=plain`
- `./gradlew lintFix --no-daemon --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b3d6db4a88320a2eac406a58d8665