### PR TITLE
Support landscape layout for CodingScreen

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/github/arashiyama11/dncl_ide/ui/layout/DnclIDE.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/arashiyama11/dncl_ide/ui/layout/DnclIDE.kt
@@ -1,0 +1,19 @@
+package io.github.arashiyama11.dncl_ide.ui.layout
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalWindowInfo
+import org.koin.compose.viewmodel.koinViewModel
+import io.github.arashiyama11.dncl_ide.adapter.IdeViewModel
+
+@Composable
+fun DnclIDE(modifier: Modifier = Modifier, viewModel: IdeViewModel = koinViewModel()) {
+    val windowInfo = LocalWindowInfo.current
+    val isLandscape = windowInfo.containerSize.width > windowInfo.containerSize.height
+    if (isLandscape) {
+        DnclIDEHorizontal(modifier, viewModel)
+    } else {
+        DnclIDEVertical(modifier, viewModel)
+    }
+}
+

--- a/composeApp/src/commonMain/kotlin/io/github/arashiyama11/dncl_ide/ui/layout/DnclIDEHorizontal.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/arashiyama11/dncl_ide/ui/layout/DnclIDEHorizontal.kt
@@ -107,7 +107,7 @@ fun DnclIDEHorizontal(modifier: Modifier = Modifier, viewModel: IdeViewModel = k
             }
         }
 
-        Column(
+        Row(
             modifier = Modifier
                 .weight(1f)
                 .fillMaxHeight()
@@ -119,14 +119,14 @@ fun DnclIDEHorizontal(modifier: Modifier = Modifier, viewModel: IdeViewModel = k
                             environment = environment,
                             modifier = Modifier
                                 .weight(1f)
-                                .fillMaxWidth()
+                                .fillMaxHeight()
                         )
                     } ?: run {
                         val textFieldDesc = "デバッグ出力"
                         OutlinedTextField(
                             value = uiState.output,
                             onValueChange = { },
-                            modifier = Modifier.weight(1f).fillMaxWidth(),
+                            modifier = Modifier.weight(1f).fillMaxHeight(),
                             textStyle = MaterialTheme.typography.bodyLarge,
                             label = { Text(textFieldDesc) },
                             readOnly = true
@@ -139,7 +139,7 @@ fun DnclIDEHorizontal(modifier: Modifier = Modifier, viewModel: IdeViewModel = k
                     OutlinedTextField(
                         value = uiState.output,
                         onValueChange = { },
-                        modifier = Modifier.weight(1f).fillMaxWidth(),
+                        modifier = Modifier.weight(1f).fillMaxHeight(),
                         textStyle = LocalCodeTypography.current.bodyLarge,
                         label = { Text(textFieldDesc) },
                         readOnly = true,
@@ -147,7 +147,7 @@ fun DnclIDEHorizontal(modifier: Modifier = Modifier, viewModel: IdeViewModel = k
                 }
             }
             with(viewModel) {
-                IdeSideButtons(Modifier.fillMaxWidth())
+                IdeSideButtons(Modifier.fillMaxHeight())
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/io/github/arashiyama11/dncl_ide/ui/layout/DnclIDEHorizontal.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/arashiyama11/dncl_ide/ui/layout/DnclIDEHorizontal.kt
@@ -1,0 +1,155 @@
+package io.github.arashiyama11.dncl_ide.ui.layout
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material3.Button
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.github.arashiyama11.dncl_ide.adapter.IdeViewModel
+import io.github.arashiyama11.dncl_ide.adapter.TextFieldType
+import io.github.arashiyama11.dncl_ide.ui.LocalCodeTypography
+import io.github.arashiyama11.dncl_ide.ui.components.CodeEditor
+import io.github.arashiyama11.dncl_ide.ui.components.EnvironmentDebugView
+import io.github.arashiyama11.dncl_ide.ui.components.IdeSideButtons
+import io.github.arashiyama11.dncl_ide.ui.components.SuggestionListView
+import org.koin.compose.viewmodel.koinViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DnclIDEHorizontal(modifier: Modifier = Modifier, viewModel: IdeViewModel = koinViewModel()) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    Row(
+        modifier = modifier
+            .fillMaxSize()
+            .imePadding()
+    ) {
+        Column(
+            modifier = Modifier
+                .weight(2f)
+                .fillMaxHeight()
+        ) {
+            Surface(
+                modifier = Modifier.fillMaxWidth().heightIn(min = 48.dp),
+                tonalElevation = 4.dp
+            ) {
+                Box(contentAlignment = Alignment.Center) {
+                    Text(uiState.selectedEntryPath?.value?.lastOrNull()?.value.orEmpty())
+                }
+            }
+
+            HorizontalDivider()
+            CodeEditor(
+                codeText = uiState.codeTextFieldValue,
+                annotatedCodeText = uiState.annotatedString,
+                onCodeChange = { viewModel.onTextChanged(it) },
+                modifier = Modifier.weight(1f),
+                fontSize = uiState.fontSize,
+                currentEvaluatingLine = uiState.currentEvaluatingLine,
+                onFocused = { viewModel.onCodeEditorFocused(it) },
+                verticalScroll = true
+            )
+
+            if (uiState.isWaitingForInput) {
+                ElevatedCard(
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 4.dp)
+                ) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        OutlinedTextField(
+                            value = uiState.currentInput,
+                            onValueChange = { viewModel.onCurrentInputChanged(it) },
+                            modifier = Modifier.weight(1f),
+                            label = { Text("入力待ち...") },
+                        )
+                        Button(
+                            onClick = { viewModel.onSendInputClicked() },
+                            enabled = uiState.running
+                        ) {
+                            Icon(Icons.AutoMirrored.Filled.Send, contentDescription = "送信")
+                        }
+                    }
+                }
+            }
+
+            AnimatedVisibility(uiState.isFocused) {
+                SuggestionListView(
+                    uiState.textSuggestions,
+                    modifier = Modifier.height(48.dp)
+                ) { viewModel.onConfirmTextSuggestion(it) }
+            }
+        }
+
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxHeight()
+        ) {
+            when (uiState.textFieldType) {
+                TextFieldType.DEBUG_OUTPUT -> {
+                    uiState.currentEnvironment?.let { environment ->
+                        EnvironmentDebugView(
+                            environment = environment,
+                            modifier = Modifier
+                                .weight(1f)
+                                .fillMaxWidth()
+                        )
+                    } ?: run {
+                        val textFieldDesc = "デバッグ出力"
+                        OutlinedTextField(
+                            value = uiState.output,
+                            onValueChange = { },
+                            modifier = Modifier.weight(1f).fillMaxWidth(),
+                            textStyle = MaterialTheme.typography.bodyLarge,
+                            label = { Text(textFieldDesc) },
+                            readOnly = true
+                        )
+                    }
+                }
+
+                TextFieldType.OUTPUT -> {
+                    val textFieldDesc = "出力"
+                    OutlinedTextField(
+                        value = uiState.output,
+                        onValueChange = { },
+                        modifier = Modifier.weight(1f).fillMaxWidth(),
+                        textStyle = LocalCodeTypography.current.bodyLarge,
+                        label = { Text(textFieldDesc) },
+                        readOnly = true,
+                    )
+                }
+            }
+            with(viewModel) {
+                IdeSideButtons(Modifier.fillMaxWidth())
+            }
+        }
+    }
+}
+

--- a/composeApp/src/commonMain/kotlin/io/github/arashiyama11/dncl_ide/ui/screen/CodingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/arashiyama11/dncl_ide/ui/screen/CodingScreen.kt
@@ -12,7 +12,7 @@ import io.github.arashiyama11.dncl_ide.domain.model.Entry
 import io.github.arashiyama11.dncl_ide.domain.model.NotebookFile
 import io.github.arashiyama11.dncl_ide.domain.model.ProgramFile
 import io.github.arashiyama11.dncl_ide.domain.repository.FileRepository
-import io.github.arashiyama11.dncl_ide.ui.layout.DnclIDEVertical
+import io.github.arashiyama11.dncl_ide.ui.layout.DnclIDE
 import org.koin.compose.koinInject
 
 @Composable
@@ -28,7 +28,7 @@ fun CodingScreen(fileRepository: FileRepository = koinInject()) {
     }
     when (entry) {
         is NotebookFile -> NotebookScreen()
-        is ProgramFile -> DnclIDEVertical()
+        is ProgramFile -> DnclIDE()
         else -> {
             Text("No file selected or unsupported file type")
         }


### PR DESCRIPTION
## Summary
- add orientation-aware `DnclIDE` which selects landscape or portrait layout
- implement new `DnclIDEHorizontal` layout to keep the editor tall when in landscape
- update `CodingScreen` to use the new layout selector

## Testing
- `./gradlew compileKotlinDesktop --no-daemon --console=plain`
- `./gradlew desktopTest --no-daemon --console=plain`
- `./gradlew lintFix --no-daemon --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b43929a6483208e8b3495e9ca43bb